### PR TITLE
fix set_data for string values

### DIFF
--- a/src/data/helpers/set_data.ts
+++ b/src/data/helpers/set_data.ts
@@ -4,7 +4,7 @@
 
 function setData ( ele: EleLoose, key: string, value: any ): void {
 
-  value = attempt ( JSON.stringify, value );
+  value = isString(value) ? value : attempt ( JSON.stringify, value );
 
   ele.dataset[camelCase ( key )] = value;
 

--- a/test/modules/data.js
+++ b/test/modules/data.js
@@ -122,6 +122,15 @@ describe ( 'Data', { beforeEach: getFixtureInit ( fixture ) }, function () {
 
     });
 
+    it ( 'doesn\'t wrap strings in extra quotes', function ( t ) {
+
+      var ele = $('div');
+
+      ele.data( 'test', 'foo' );
+
+      t.is ( ele[0].getAttribute('data-test'), 'foo');
+    });
+
   });
 
 });


### PR DESCRIPTION
Avoid wrapping DOM data attributes in double quotes.

Previous behaviour:
```
ele.data('test', 'foo');
ele[0].getAttribute('data-test') == '"foo"'
```

New behaviour:
```
ele.data('test', 'foo');
ele[0].getAttribute('data-test') == 'foo'
```

JSON.stringify on a string will wrap it in double quotes.
I don't think we actually want that in the DOM,
and it unnecessarily diverges from JQuery behaviour.

My change doesn't modify the way `ele.data` works,
just the way it is represented in the DOM,
to make it compatible with JQuery.