### PR TITLE
Update css.ts to add missing declaration

### DIFF
--- a/src/css/css.ts
+++ b/src/css/css.ts
@@ -8,6 +8,7 @@
 // @require ./helpers/is_css_variable.ts
 
 interface Cash {
+  css ( prop: string[] ): Record<string, number | string>;
   css ( prop: string ): string | undefined;
   css ( prop: string, value: number | string ): this;
   css ( props: Record<string, number | string> ): this;


### PR DESCRIPTION
Passing an array of style properties to .css() returns an object of property-value pairs,
Added declaration to satisfy following ts objection

```const { display, position } = $el.css(["display", "position"]) >>> No overload matches this call.```