### PR TITLE
Avoid duplicate quotes when using data()

### DIFF
--- a/src/data/helpers/set_data.ts
+++ b/src/data/helpers/set_data.ts
@@ -4,7 +4,7 @@
 
 function setData ( ele: EleLoose, key: string, value: any ): void {
 
-  value = attempt ( JSON.stringify, value );
+  value = typeof value === 'string' || value instanceof String ? value : attempt ( JSON.stringify, value );
 
   ele.dataset[camelCase ( key )] = value;
 


### PR DESCRIPTION
`JSON.stringify()` adds quotes around a string value leading to `data-id=""123""` instead of `data-id="123"`.