### PR TITLE
Allow to use filter on plain arrays

### DIFF
--- a/src/core/get_compare_function.ts
+++ b/src/core/get_compare_function.ts
@@ -10,8 +10,10 @@ function getCompareFunction ( comparator?: Comparator ): (( i: number, ele: EleL
              ? comparator
              : isCash ( comparator )
                ? ( i: number, ele: EleLoose ) => comparator.is ( ele )
-               : !comparator
-                 ? () => false
-                 : ( i: number, ele: EleLoose ) => ele === comparator;
+               : isArray(comparator)
+                 ? ( i: number, ele: EleLoose ) => comparator.indexOf ( ele ) >= 0
+                 : !comparator
+                   ? () => false
+                   : ( i: number, ele: EleLoose ) => ele === comparator;
 
 }

--- a/test/modules/collection.js
+++ b/test/modules/collection.js
@@ -142,6 +142,15 @@ describe ( 'Collection', { beforeEach: getFixtureInit ( fixture ) }, function ()
 
     });
 
+    it ( 'supports array', function ( t ) {
+
+      var collection = $([0, 1, 2, 3, 4]);
+      var filtered = collection.filter ( [0, 3] ).get ();
+
+      t.deepEqual ( filtered, [0, 3] );
+
+    });
+
     it ( 'doesn\'t throw with an empty selector', function ( t ) {
 
       $('*').filter ( '' );

--- a/test/modules/traversal.js
+++ b/test/modules/traversal.js
@@ -330,7 +330,7 @@ describe ( 'Traversal', { beforeEach: getFixtureInit ( fixture ) }, function () 
     it ( 'works with arrays', function ( t ) {
 
       var collection = $([0, 1, 2, 3, 4]);
-      var filtered = collection.not( [1, 3] ).get();
+      var filtered = collection.not( [1, 3] ).get ();
 
       t.deepEqual ( filtered, [0, 2, 4] );
 

--- a/test/modules/traversal.js
+++ b/test/modules/traversal.js
@@ -327,6 +327,15 @@ describe ( 'Traversal', { beforeEach: getFixtureInit ( fixture ) }, function () 
 
     });
 
+    it ( 'works with arrays', function ( t ) {
+
+      var collection = $([0, 1, 2, 3, 4]);
+      var filtered = collection.not( [1, 3] ).get();
+
+      t.deepEqual ( filtered, [0, 2, 4] );
+
+    });
+
   });
 
   describe ( '$.fn.parent', function ( it ) {


### PR DESCRIPTION
jQuery allows to use `.filter(arrayLike)` and `.not(arrayLike)` on a non-node collections.

This commit adds this ability for arrays:

```js
$([1, 2, 3]).filter([2, 3, 4]) // returns [2, 3]
$([1, 2, 3]).not([2, 3, 4]) // returns [1]
```