### PR TITLE
Align serialize with jQuery 2 and newer

### DIFF
--- a/src/forms/helpers/query_encode.ts
+++ b/src/forms/helpers/query_encode.ts
@@ -1,9 +1,8 @@
 
-const queryEncodeSpaceRe = /%20/g;
 const queryEncodeCRLFRe = /\r?\n/g;
 
 function queryEncode ( prop: string, value: string ): string {
 
-  return `&${encodeURIComponent ( prop )}=${encodeURIComponent ( value.replace ( queryEncodeCRLFRe, '\r\n' ) ).replace ( queryEncodeSpaceRe, '+' )}`;
+  return `&${encodeURIComponent ( prop )}=${encodeURIComponent ( value.replace ( queryEncodeCRLFRe, '\r\n' ) )}`;
 
 }

--- a/test/modules/forms.js
+++ b/test/modules/forms.js
@@ -2,7 +2,7 @@
 var fixture = '\
   <form class="form">\
     <input type="hidden" value="5" name="hidden"/>\
-    <input type="text" value="text" name="text"/>\
+    <input type="text" value="text with spaces" name="text"/>\
     <input type="text" value="disabled" name="disabled-check" disabled />\
     <input type="checkbox" value="yes" checked="checked" name="checkbox-yes" />\
     <input type="checkbox" value="no" name="checkbox-no" />\
@@ -32,7 +32,7 @@ describe ( 'Forms', { beforeEach: getFixtureInit ( fixture ) }, function () {
 
       var val = $('.form').serialize ();
 
-      t.is ( val, 'hidden=5&text=text&checkbox-yes=yes&radio=yes&select=selected&select-multiple=option-1&select-multiple=option-2' );
+      t.is ( val, 'hidden=5&text=text%20with%20spaces&checkbox-yes=yes&radio=yes&select=selected&select-multiple=option-1&select-multiple=option-2' );
 
     });
 
@@ -40,7 +40,7 @@ describe ( 'Forms', { beforeEach: getFixtureInit ( fixture ) }, function () {
 
       var val = $('.form input[type=text]').serialize ();
 
-      t.is ( val, 'text=text' );
+      t.is ( val, 'text=text%20with%20spaces' );
 
     });
 
@@ -48,7 +48,7 @@ describe ( 'Forms', { beforeEach: getFixtureInit ( fixture ) }, function () {
 
       var val = $('.form input, .form textarea, .form select').serialize ();
 
-      t.is ( val, 'hidden=5&text=text&checkbox-yes=yes&radio=yes&select=selected&select-multiple=option-1&select-multiple=option-2' );
+      t.is ( val, 'hidden=5&text=text%20with%20spaces&checkbox-yes=yes&radio=yes&select=selected&select-multiple=option-1&select-multiple=option-2' );
 
     });
 
@@ -68,7 +68,7 @@ describe ( 'Forms', { beforeEach: getFixtureInit ( fixture ) }, function () {
 
       var val = $('.form input[type=text]').val ();
 
-      t.is ( val, 'text' );
+      t.is ( val, 'text with spaces' );
 
     });
 


### PR DESCRIPTION
jQuery no longer serializes spaces as `+`. They left the old logic for the ajax "form-urlencoded" type only.

Here is commit in jquery repo: https://github.com/jquery/jquery/commit/70605c8e5655da996ebd395e3c43423daaa08d9c