### PR TITLE
Replaced initEvent to new Event

### DIFF
--- a/src/events/trigger.ts
+++ b/src/events/trigger.ts
@@ -20,10 +20,9 @@ fn.trigger = function ( this: Cash, event: Event | string, data?: any ) {
 
     if ( !name ) return this;
 
-    const type = eventsMouseRe.test ( name ) ? 'MouseEvents' : 'HTMLEvents';
+    const EventClass = eventsMouseRe.test ( name ) ? MouseEvent : Event;
 
-    event = doc.createEvent ( type );
-    event.initEvent ( name, true, true );
+    event = new EventClass ( name, { bubbles: true, cancelable: true } ) as Event;
     event.namespace = namespaces.join ( eventsNamespacesSeparator );
     event.___ot = nameOriginal;
 


### PR DESCRIPTION
[initEvent](https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent) is no longer recommended.

The standard is `new Event` or `new MouseEvent` instead of `document.createEvent` + `event.initEvent`