### PR TITLE
EventCache: Replaced property access to WeakMap access

### DIFF
--- a/src/events/helpers/get_events_cache.ts
+++ b/src/events/helpers/get_events_cache.ts
@@ -2,7 +2,7 @@
 // @require ./variables.ts
 
 function getEventsCache ( ele: EleLoose ): { [event: string]: [string[], string, EventCallback][] } {
-
-  return ele[eventsNamespace] = ( ele[eventsNamespace] || {} );
-
+  let cache = eventsWeakMapCache.get( ele );
+  if ( !cache ) eventsWeakMapCache.set( ele, cache = {} );
+  return cache;
 }

--- a/src/events/helpers/variables.ts
+++ b/src/events/helpers/variables.ts
@@ -1,5 +1,5 @@
 
-const eventsNamespace = '___ce';
+const eventsWeakMapCache = new WeakMap ();
 const eventsNamespacesSeparator = '.';
 const eventsFocus: { [event: string]: string | undefined } = { focus: 'focusin', blur: 'focusout' };
 const eventsHover: { [event: string]: string | undefined } = { mouseenter: 'mouseover', mouseleave: 'mouseout' };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ES2015.Collection"],
     "forceConsistentCasingInFileNames": true,
     "noUnusedParameters": false,
     "strictNullChecks": false


### PR DESCRIPTION
As per #383. Shall resolve #317 as well. Once PR merged, closes #383.

Chrome 36+, Edge 12+, Safari 8+, Firefox 6+, Opera 23+, IE 11+ 
[caniuse - WeakMap](https://caniuse.com/?search=WeakMap())

Besides, `"lib": ["ES2015.Collection"]` is added to `tsconfig.json` 
(`Map`, `Set`, `WeakMap`, `WeakSet` are added to TypeScript)

Please note that, element clone would not copy the event cache. This matches the result that `element.cloneNode(true)` would not copy the event handlers attached to the original node. 
