### PR TITLE
Readme update: Browser compatibility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 
 # Cash
 
-Cash is an absurdly small jQuery alternative for modern browsers (IE11+) that provides jQuery-style syntax for manipulating the DOM. Utilizing modern browser features to minimize the codebase, developers can use the familiar chainable methods at a fraction of the file size. 100% feature parity with jQuery isn't a goal, but Cash comes helpfully close, covering most day to day use cases.
+Cash is an absurdly small jQuery alternative for modern browsers (2015+ browsers except IE; Chrome 36+, Edge 12+, Safari 8+, Firefox 11+, Opera 23+) that provides jQuery-style syntax for manipulating the DOM. Utilizing modern browser features to minimize the codebase, developers can use the familiar chainable methods at a fraction of the file size. 100% feature parity with jQuery isn't a goal, but Cash comes helpfully close, covering most day to day use cases.
 
 ## Comparison
 


### PR DESCRIPTION
As per introduction of `WeakMap` in #423 and dropped `initEvent` with IE11 in #422.

Here provides a definition of the versions that this script shall work with.

**modern browsers (2015+ browsers except IE; Chrome 36+, Edge 12+, Safari 8+, Firefox 11+, Opera 23+)**

Reference: [new MouseEvent](https://caniuse.com/?search=MouseEvent()) and [new WeakMap](https://caniuse.com/?search=weakmap)