### PR TITLE
$.data: ensure the value is not quoted

### DIFF
--- a/src/data/helpers/set_data.ts
+++ b/src/data/helpers/set_data.ts
@@ -4,7 +4,7 @@
 
 function setData ( ele: EleLoose, key: string, value: any ): void {
 
-  value = attempt ( JSON.stringify, value );
+  value = attempt ( JSON.stringify, value ).replace(/^"(.*)"$/, "$1");
 
   ele.dataset[camelCase ( key )] = value;
 


### PR DESCRIPTION
Fixes #426 

The new value of the dataset is passed into JSON.stringify(), which adds the unnecessary double quotes. I took the stringified value and stripped the double quotes away.

I am not sure whether JSON.stringify() is needed at all. Maybe getting rid of the stringify() makes more sense than wrapping it with my replace thing.