### PR TITLE
docs: latest filesize comparsions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,11 +9,11 @@ Cash is an absurdly small jQuery alternative for modern browsers (IE11+) that pr
 
 ## Comparison
 
-| Size               | Cash        | Zepto 1.2.0 | jQuery Slim 3.4.1 |
-| ------------------ | ----------- | ----------- | ----------------- |
-| Unminified         | **36.5 KB** | 58.7 KB     | 227 KB            |
-| Minified           | **16 KB**   | 26 KB       | 71 KB             |
-| Minified & Gzipped | **6 KB**    | 9.8 KB      | 24.4 KB           |
+| Size               | Cash 8.1.5   | Zepto 1.2.0   | jQuery Slim 3.7.1    |
+| ------------------ | ------------ | ------------- | -------------------- |
+| Unminified         | **41.6 KB**  | 57.3 KB       | 226.6 KB             |
+| Minified           | **16.5 KB**  | 25.8 KB       | 68.6 KB              |
+| Minified & Gzipped | **6.1 KB**   | 9.6 KB        | 23.5 KB              |
 
 A **76.6%** gain in size reduction compared to jQuery Slim. If you need a smaller bundle, we support [partial builds](https://github.com/fabiospampinato/cash/blob/master/docs/partial_builds.md) too.
 


### PR DESCRIPTION
The results are based on the gzip compression provided by cdnjs on the latest versions of all the mentioned libraries, and obtained using the tool https://smallseotools.com/check-gzip-compression/.

All the figures are rounded to 1 decimal place.

### Source

https://cdnjs.com/libraries/cash
https://cdnjs.com/libraries/zepto
https://cdnjs.com/libraries/jquery/3.4.1
https://cdnjs.com/libraries/jquery/3.7.1

### Cross-checked with https://zeptojs.com/

<img width="607" alt="Screen Shot 2023-12-02 at 16 52 49" src="https://github.com/fabiospampinato/cash/assets/44498510/6abf5fb2-109b-4ac6-9390-acd4eeca4e8a">
